### PR TITLE
Fixed syntactic issues

### DIFF
--- a/cloudantplus.js
+++ b/cloudantplus.js
@@ -106,8 +106,8 @@ module.exports = function(RED) {
                 node.warn(err.description, err);
                 node.status({fill:"yellow",shape:"ring",text:"retrying..."});
                 setTimeout(function () {
-                  doConnect(credentials, tryNum + 1)
-                }, node.timeout)
+                  doConnect(credentials, tryNum + 1);
+                }, node.timeout);
               } else {
                 node.error(err.description, err);
                 node.status({fill:"red",shape:"dot",text:err.description});
@@ -124,8 +124,8 @@ module.exports = function(RED) {
                   handleMessage(cloudant, node, msg);
               });
             }
-          })
-        };
+          });
+        }
 
         function createDatabase(cloudant, node) {
           cloudant.db.list(function(err, all_dbs) {
@@ -237,7 +237,7 @@ module.exports = function(RED) {
             callback(err, body);
           });
         }
-    };
+    }
     RED.nodes.registerType("cloudantplus out", CloudantOutNode);
 
     function CloudantInNode(n) {
@@ -271,7 +271,9 @@ module.exports = function(RED) {
               if (tryNum <= node.retries) {
                 node.warn(err.description, err);
                 node.status({fill:"yellow",shape:"ring",text:"retrying..."});
-                setTimeout(function() { doConnect(credentials, tryNum + 1) }, node.timeout)
+                setTimeout(function () {
+                  doConnect(credentials, tryNum + 1);
+                }, node.timeout);
               } else {
                 node.error(err.description, err);
                 node.status({fill:"red",shape:"dot",text:err.description});
@@ -279,12 +281,14 @@ module.exports = function(RED) {
             } else {
               node.status({fill:"green",shape:"dot",text:"connected"});
               node.on("input", function(msg) {
-                if (err) { return node.error(err.description, err); }
+                if (err) {
+                    return node.error(err.description, err);
+                }
                 handleMsg(cloudant, node, msg);
               });
             }
-          })
-        };
+          });
+        }
 
 
         function handleMsg(cloudant, node, msg) {
@@ -320,7 +324,7 @@ module.exports = function(RED) {
                   sendDocumentOnPayload(err, body, msg);
               });
           }
-        };
+        }
 
         function getDocumentId(payload) {
             if (typeof payload === "object") {


### PR DESCRIPTION
Tested with the use case described in #1 .

This is the Node-RED output at startup:

```
Welcome to Node-RED
===================

21 Nov 14:37:36 - [info] Node-RED version: v0.17.5
21 Nov 14:37:36 - [info] Node.js  version: v6.12.0
21 Nov 14:37:36 - [info] Linux 4.9.49-moby x64 LE
21 Nov 14:37:36 - [info] Loading palette nodes
21 Nov 14:37:39 - [warn] ------------------------------------------------------
21 Nov 14:37:39 - [warn] [rpi-gpio] Info : Ignoring Raspberry Pi specific node
21 Nov 14:37:39 - [warn] ------------------------------------------------------
21 Nov 14:37:39 - [info] Settings file  : /data/settings.js
21 Nov 14:37:39 - [info] User directory : /data
21 Nov 14:37:39 - [info] Flows file     : /data/flows.json
21 Nov 14:37:39 - [info] Server now running at http://127.0.0.1:1880/
21 Nov 14:37:39 - [info] Starting flows
21 Nov 14:37:39 - [info] Started flows
21 Nov 14:37:42 - [warn] [cloudantplus out:insert-policy-rules] socket hang up
21 Nov 14:37:43 - [warn] [cloudantplus out:insert-policy-rules] connect ECONNREFUSED x.x.x.x:xx
```

When I open the flow I can see the the gree icon that says `connected`.

<img width="251" alt="cloudant-plus-connected-icon" src="https://user-images.githubusercontent.com/8156463/33078524-d52497a0-ceca-11e7-92c6-b7943e1bd6b1.png">
